### PR TITLE
Use Docker in Travis CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,7 @@
 language: java
+
+services:
+  - docker
+
+script:
+  - docker-compose build tests && docker-compose run tests


### PR DESCRIPTION
Since we will eventually have tests that will need instances of MongoDB or
databases / technologies running, this commit adds Docker support when running
Travis CI jobs.